### PR TITLE
Restrict security group CIDRs

### DIFF
--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -6,21 +6,21 @@ resource "aws_security_group" "alb_sg" {
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.allowed_alb_ingress_cidrs
   }
 
   ingress {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.allowed_alb_ingress_cidrs
   }
 
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [var.vpc_cidr]
   }
 }
 
@@ -46,6 +46,6 @@ resource "aws_security_group" "app_sg" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [var.vpc_cidr]
   }
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,9 +1,34 @@
-variable "name"        { type = string, default = "saas" }
-variable "aws_region"  { type = string, default = "us-east-1" }
-variable "vpc_cidr"    { type = string, default = "10.0.0.0/16" }
-variable "instance_type" { type = string, default = "t3.micro" }
-variable "ami_id"      { type = string, default = "ami-08c40ec9ead489470" } # Amazon Linux 2
+variable "name" {
+  type    = string
+  default = "saas"
+}
+
+variable "aws_region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "vpc_cidr" {
+  type    = string
+  default = "10.0.0.0/16"
+}
+
+variable "instance_type" {
+  type    = string
+  default = "t3.micro"
+}
+
+variable "ami_id" {
+  type    = string
+  default = "ami-08c40ec9ead489470" # Amazon Linux 2
+}
 variable "acm_certificate_arn" {
   description = "ACM certificate ARN used by ALB HTTPS (443)"
   type        = string
+}
+
+variable "allowed_alb_ingress_cidrs" {
+  description = "List of CIDR blocks allowed to access the ALB"
+  type        = list(string)
+  default     = ["198.51.100.0/24"]
 }


### PR DESCRIPTION

- restrict ALB ingress to configurable CIDR blocks instead of 0.0.0.0/0 - limit ALB and app sg -  add `allowed_alb_ingress_cidrs` variable